### PR TITLE
Native OS notifications: [Nexus] <instance> — <message>

### DIFF
--- a/src/main/core/eventBus.ts
+++ b/src/main/core/eventBus.ts
@@ -14,6 +14,12 @@ export interface NexusEvents {
   'view:ready': { instanceId: string };
   'view:load-failed': { instanceId: string; error: string };
   'notification:update': UnreadUpdate;
+  'notification:native': {
+    instanceId: string;
+    title: string;
+    body: string;
+    tag?: string;
+  };
   'theme:changed': { themeId: string };
   'settings:changed': { key: string };
 }

--- a/src/main/notifyPreload.ts
+++ b/src/main/notifyPreload.ts
@@ -1,0 +1,35 @@
+// Nexus notification preload.
+//
+// Loaded into every service view via session.setPreloads(), alongside any
+// module-specific preload. Runs in the isolated world with contextIsolation,
+// so it cannot directly touch window.Notification in the page's main world.
+//
+// The main world's shim (injected via webContents.executeJavaScript at
+// dom-ready) dispatches a CustomEvent('nexus-notify') on `document`. DOM
+// events cross the isolated-world boundary because the DOM itself is
+// shared, so this preload hears them and forwards payload to the main
+// process via ipcRenderer.send.
+//
+// Channel contract (see src/shared/types.ts IPC.NOTIFY_SHOW):
+//   { title: string, body: string, tag?: string, icon?: string }
+
+import { ipcRenderer } from 'electron';
+
+function coerceString(v: unknown, max: number): string {
+  if (typeof v !== 'string') return '';
+  return v.slice(0, max);
+}
+
+document.addEventListener('nexus-notify', (event: Event) => {
+  const detail = (event as CustomEvent).detail;
+  if (!detail || typeof detail !== 'object') return;
+  const d = detail as Record<string, unknown>;
+  const payload = {
+    title: coerceString(d.title, 256),
+    body: coerceString(d.body, 1024),
+    tag: coerceString(d.tag, 128),
+    icon: coerceString(d.icon, 2048),
+  };
+  if (!payload.title && !payload.body) return;
+  ipcRenderer.send('nexus:notify:show', payload);
+});

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -65,6 +65,8 @@ const api = {
     return () => ipcRenderer.removeListener(IPC.UNREAD_UPDATE, listener);
   },
   getAllUnread: (): Promise<Record<string, number>> => invoke(IPC.UNREAD_ALL),
+  setNotificationsEnabled: (enabled: boolean): Promise<void> =>
+    invoke(IPC.NOTIFY_SET_ENABLED, enabled),
 };
 
 contextBridge.exposeInMainWorld('nexus', api);

--- a/src/main/services/ipcService.ts
+++ b/src/main/services/ipcService.ts
@@ -176,6 +176,13 @@ export class IpcService implements Service {
 
     this.router.register(IPC.UNREAD_ALL, { handler: () => notifications.all() });
 
+    this.router.register(IPC.NOTIFY_SET_ENABLED, {
+      input: z.boolean(),
+      handler: (enabled) => {
+        settings.setNotificationsEnabled(enabled);
+      },
+    });
+
     this.router.register(IPC.SIDEBAR_UPDATE_LAYOUT, {
       input: sidebarLayoutSchema,
       handler: (layout) => {

--- a/src/main/services/notificationService.ts
+++ b/src/main/services/notificationService.ts
@@ -1,9 +1,34 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, Notification as ElectronNotification } from 'electron';
 import { IPC } from '../../shared/types';
 import type { UnreadUpdate } from '../../shared/types';
 import type { Service, ServiceContext } from '../core/service';
 import type { Logger } from '../core/logger';
 import type { WindowService } from './windowService';
+import type { SettingsService } from './settingsService';
+import type { ViewService } from './viewService';
+
+/**
+ * Format the title/body pair we show in the native OS notification.
+ * Pure, so it's easy to unit-test.
+ *
+ *   format({ instanceName: 'Work', title: 'John Doe', body: 'Lunch?' })
+ *     => { title: '[Nexus] Work', body: 'John Doe: Lunch?' }
+ *
+ * Empty source title leaves the body unchanged (no leading colon).
+ */
+export function formatNativeNotification(input: {
+  instanceName: string;
+  title: string;
+  body: string;
+}): { title: string; body: string } {
+  const t = (input.title ?? '').trim();
+  const b = (input.body ?? '').trim();
+  const composedBody = t && b ? `${t}: ${b}` : t || b || '';
+  return {
+    title: `[Nexus] ${input.instanceName}`,
+    body: composedBody,
+  };
+}
 
 export class NotificationService implements Service {
   readonly name = 'notifications';
@@ -11,15 +36,22 @@ export class NotificationService implements Service {
   private counts = new Map<string, number>();
   private previews = new Map<string, string>();
   private windowService!: WindowService;
+  private settings!: SettingsService;
+  private views!: ViewService;
   private unsubscribe: (() => void)[] = [];
 
   async init(ctx: ServiceContext): Promise<void> {
     this.logger = ctx.logger.child('notifications');
     this.windowService = ctx.container.get<WindowService>('window');
+    this.settings = ctx.container.get<SettingsService>('settings');
+    this.views = ctx.container.get<ViewService>('views');
 
     this.unsubscribe.push(
       ctx.bus.on('notification:update', (u) => this.report(u)),
       ctx.bus.on('instance:removed', ({ instanceId }) => this.clear(instanceId)),
+      ctx.bus.on('notification:native', ({ instanceId, title, body, tag }) => {
+        this.showNative(instanceId, title, body, tag);
+      }),
     );
   }
 
@@ -59,6 +91,54 @@ export class NotificationService implements Service {
     const total = [...this.counts.values()].reduce((s, n) => s + n, 0);
     if (process.platform === 'darwin') {
       app.dock?.setBadge(total > 0 ? String(total) : '');
+    }
+  }
+
+  /**
+   * Show a native OS notification for a message received inside an embedded
+   * service view. Gated on:
+   *   - global settings.notificationsEnabled (default true)
+   *   - Electron Notification.isSupported() for the current platform
+   */
+  private showNative(instanceId: string, title: string, body: string, _tag?: string): void {
+    if (this.settings.state.notificationsEnabled === false) return;
+    if (!ElectronNotification.isSupported()) {
+      this.logger.debug('native notifications not supported on this platform');
+      return;
+    }
+    const instance = this.settings.getInstance(instanceId);
+    if (!instance) return;
+
+    const { title: nTitle, body: nBody } = formatNativeNotification({
+      instanceName: instance.name,
+      title,
+      body,
+    });
+
+    try {
+      const notif = new ElectronNotification({
+        title: nTitle,
+        body: nBody,
+        subtitle: process.platform === 'darwin' ? 'Nexus' : undefined,
+        silent: false,
+      });
+      notif.on('click', () => {
+        const win = this.windowService.getWindow();
+        if (win && !win.isDestroyed()) {
+          if (win.isMinimized()) win.restore();
+          win.show();
+          win.focus();
+        }
+        try {
+          this.views.activate(instanceId);
+          this.settings.setActive(instanceId);
+        } catch (err) {
+          this.logger.warn(`notification activate failed for ${instanceId}`, err);
+        }
+      });
+      notif.show();
+    } catch (err) {
+      this.logger.warn('failed to show native notification', err);
     }
   }
 }

--- a/src/main/services/notifications/mainWorldShim.ts
+++ b/src/main/services/notifications/mainWorldShim.ts
@@ -1,0 +1,82 @@
+/**
+ * Main-world Notification shim.
+ *
+ * Returned as a string to be injected into a service view's page context via
+ * webContents.executeJavaScript(shim, true). It replaces window.Notification
+ * so that the page's new Notification(...) calls become CustomEvents on
+ * document, which the Nexus isolated-world preload catches.
+ *
+ * Designed to be self-contained, idempotent, and safe to re-run on every
+ * dom-ready (e.g. after an in-service reload).
+ */
+export const mainWorldNotificationShim = `(() => {
+  try {
+    if (window.__nexusNotifyInstalled) return;
+    window.__nexusNotifyInstalled = true;
+
+    const Original = window.Notification;
+
+    function dispatch(detail) {
+      try {
+        document.dispatchEvent(new CustomEvent('nexus-notify', { detail }));
+      } catch (e) {
+        // If the page locks down CustomEvent we silently no-op.
+      }
+    }
+
+    function NexusNotification(title, options) {
+      const opts = options || {};
+      dispatch({
+        title: typeof title === 'string' ? title : String(title || ''),
+        body: typeof opts.body === 'string' ? opts.body : '',
+        tag: typeof opts.tag === 'string' ? opts.tag : '',
+        icon: typeof opts.icon === 'string' ? opts.icon : '',
+      });
+      // Return a minimal Notification-like object so callers that hold a
+      // reference and call .close() or assign event handlers don't crash.
+      const stub = {
+        title: title,
+        body: opts.body || '',
+        tag: opts.tag || '',
+        icon: opts.icon || '',
+        onclick: null,
+        onshow: null,
+        onclose: null,
+        onerror: null,
+        close: function () {},
+        addEventListener: function () {},
+        removeEventListener: function () {},
+        dispatchEvent: function () { return false; },
+      };
+      return stub;
+    }
+
+    NexusNotification.permission = 'granted';
+    NexusNotification.requestPermission = function (cb) {
+      if (typeof cb === 'function') {
+        try { cb('granted'); } catch (e) {}
+      }
+      return Promise.resolve('granted');
+    };
+
+    // Preserve any prototype the page might introspect.
+    if (Original && Original.prototype) {
+      try {
+        NexusNotification.prototype = Original.prototype;
+      } catch (e) {}
+    }
+
+    try {
+      Object.defineProperty(window, 'Notification', {
+        configurable: true,
+        writable: true,
+        value: NexusNotification,
+      });
+    } catch (e) {
+      // Fall back to direct assignment.
+      window.Notification = NexusNotification;
+    }
+  } catch (e) {
+    // Never let the shim crash the page.
+  }
+})();`;

--- a/src/main/services/settingsService.ts
+++ b/src/main/services/settingsService.ts
@@ -11,6 +11,7 @@ const DEFAULT_STATE: AppState = {
   activeInstanceId: null,
   instances: [],
   themeId: 'nexus-dark',
+  notificationsEnabled: true,
   sidebarLayout: defaultLayout(),
   windowState: { width: 1280, height: 820 },
 };
@@ -179,6 +180,12 @@ export class SettingsService implements Service {
   setTheme(id: string): void {
     if (this._state.themeId === id) return;
     this._state = { ...this._state, themeId: id };
+    this.queueWrite();
+  }
+
+  setNotificationsEnabled(enabled: boolean): void {
+    if (this._state.notificationsEnabled === enabled) return;
+    this._state = { ...this._state, notificationsEnabled: enabled };
     this.queueWrite();
   }
 

--- a/src/main/services/viewService.ts
+++ b/src/main/services/viewService.ts
@@ -10,6 +10,7 @@ import type { WindowService } from './windowService';
 import type { SettingsService } from './settingsService';
 import { DefaultStrategyFactory } from './notifications/strategies';
 import type { NotificationStrategy, StrategyFactory } from './notifications/strategy';
+import { mainWorldNotificationShim } from './notifications/mainWorldShim';
 import { hardenSession, installNavigationGuard, resolveModuleFile } from '../core/security';
 
 interface ManagedView {
@@ -180,6 +181,12 @@ export class ViewService implements Service {
     const origin = new URL(manifest.url).origin;
     hardenSession(ses, origin, this.logger);
 
+    // Install the Nexus notification preload on this session so window.Notification
+    // calls from the page are forwarded to the main process. Must be set before
+    // the first loadURL so the very first frame picks it up.
+    const notifyPreloadPath = path.join(__dirname, '..', 'notifyPreload.js');
+    ses.setPreloads([...ses.getPreloads(), notifyPreloadPath]);
+
     let preloadAbs: string | undefined;
     if (manifest.inject?.preload) {
       const p = resolveModuleFile(mod.path, manifest.inject.preload);
@@ -207,6 +214,15 @@ export class ViewService implements Service {
     installNavigationGuard(view.webContents, origin, this.logger);
 
     view.webContents.on('dom-ready', async () => {
+      // 1. Inject the Nexus main-world Notification shim. Idempotent — safe to
+      //    re-run on reload. Must run in the main world (second arg = true).
+      try {
+        await view.webContents.executeJavaScript(mainWorldNotificationShim, true);
+      } catch (err) {
+        this.logger.warn(`notification shim inject failed for ${instance.id}`, err);
+      }
+
+      // 2. Inject module-specific CSS if declared in the manifest.
       if (manifest.inject?.css) {
         const cssPath = resolveModuleFile(mod.path, manifest.inject.css);
         if (!cssPath) {
@@ -221,6 +237,23 @@ export class ViewService implements Service {
         }
       }
       this.ctx.bus.emit('view:ready', { instanceId: instance.id });
+    });
+
+    // Listen for notification forwards from the preload and bubble them
+    // through the event bus so NotificationService can present them natively.
+    view.webContents.ipc.on('nexus:notify:show', (_event, raw: unknown) => {
+      if (!raw || typeof raw !== 'object') return;
+      const r = raw as { title?: unknown; body?: unknown; tag?: unknown };
+      const title = typeof r.title === 'string' ? r.title : '';
+      const body = typeof r.body === 'string' ? r.body : '';
+      const tag = typeof r.tag === 'string' ? r.tag : undefined;
+      if (!title && !body) return;
+      this.ctx.bus.emit('notification:native', {
+        instanceId: instance.id,
+        title,
+        body,
+        tag,
+      });
     });
 
     view.webContents.on('did-fail-load', (_e, code, desc, url) => {

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -12,6 +12,8 @@ export function SettingsPanel({ onClose }: Props) {
   const [tab, setTab] = useState<Tab>('modules');
   const modules = useNexus((s) => s.modules);
   const instances = useNexus((s) => s.state.instances);
+  const notificationsEnabled = useNexus((s) => s.state.notificationsEnabled ?? true);
+  const setNotificationsEnabled = useNexus((s) => s.setNotificationsEnabled);
   const addInstance = useNexus((s) => s.addInstance);
   const removeInstance = useNexus((s) => s.removeInstance);
   const reload = useNexus((s) => s.reloadModules);
@@ -101,6 +103,23 @@ export function SettingsPanel({ onClose }: Props) {
                   Open modules folder
                 </button>
               </div>
+
+              <label className="settings-toggle">
+                <input
+                  type="checkbox"
+                  checked={notificationsEnabled}
+                  onChange={(e) => setNotificationsEnabled(e.target.checked)}
+                />
+                <div>
+                  <div className="settings-toggle-title">Native notifications</div>
+                  <div className="settings-toggle-desc">
+                    Show native OS notifications when any instance receives a message.
+                    Format: <code>[Nexus] &lt;instance name&gt;</code> with the message content
+                    as the body. Click a notification to focus that instance.
+                  </div>
+                </div>
+              </label>
+
               <p className="editor-hint">
                 A <strong>module</strong> is the template for a messaging service. You can add
                 multiple <strong>instances</strong> of any module to log in with separate accounts —

--- a/src/renderer/nexus.d.ts
+++ b/src/renderer/nexus.d.ts
@@ -41,6 +41,7 @@ declare global {
 
       onUnread(cb: (update: UnreadUpdate) => void): () => void;
       getAllUnread(): Promise<Record<string, number>>;
+      setNotificationsEnabled(enabled: boolean): Promise<void>;
     };
   }
 }

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -44,6 +44,7 @@ interface NexusStore {
   setTheme(id: string): Promise<void>;
   saveTheme(theme: Theme): Promise<void>;
   deleteTheme(id: string): Promise<void>;
+  setNotificationsEnabled(enabled: boolean): Promise<void>;
   exportThemePack(
     ids: string[],
     meta?: { name?: string; author?: string },
@@ -71,6 +72,7 @@ const DEFAULT_STATE: AppState = {
   activeInstanceId: null,
   instances: [],
   themeId: 'nexus-dark',
+  notificationsEnabled: true,
   sidebarLayout: defaultLayout(),
 };
 
@@ -162,6 +164,11 @@ export const useNexus = create<NexusStore>((set, get) => ({
       themes,
       state: s.state.themeId === id ? { ...s.state, themeId: 'nexus-dark' } : s.state,
     }));
+  },
+
+  async setNotificationsEnabled(enabled) {
+    await window.nexus.setNotificationsEnabled(enabled);
+    set((s) => ({ state: { ...s.state, notificationsEnabled: enabled } }));
   },
 
   async exportThemePack(ids, meta) {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -915,6 +915,44 @@ kbd {
   border-radius: var(--nx-radius-sm);
 }
 
+.settings-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  margin: 8px 0 12px;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--nx-radius-sm);
+  background: var(--nx-sidebar);
+  cursor: pointer;
+}
+
+.settings-toggle input[type='checkbox'] {
+  margin-top: 3px;
+  accent-color: var(--nx-accent);
+  transform: scale(1.2);
+}
+
+.settings-toggle-title {
+  color: var(--nx-text);
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.settings-toggle-desc {
+  color: var(--nx-text-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.settings-toggle-desc code {
+  background: var(--nx-bg);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
 .theme-field {
   display: grid;
   grid-template-columns: 60px 1fr;

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -109,6 +109,7 @@ export const appStateSchema = z.object({
   activeInstanceId: z.string().nullable(),
   instances: z.array(moduleInstanceSchema),
   themeId: themeIdSchema,
+  notificationsEnabled: z.boolean().optional(),
   sidebarLayout: sidebarLayoutSchema.optional(),
   windowState: z
     .object({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -61,4 +61,6 @@ export const IPC = {
   APP_CLEAR_ALL_DATA: 'nexus:app:clear-all-data',
   UNREAD_UPDATE: 'nexus:unread:update',
   UNREAD_ALL: 'nexus:unread:all',
+  NOTIFY_SHOW: 'nexus:notify:show',
+  NOTIFY_SET_ENABLED: 'nexus:notify:set-enabled',
 } as const;

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -119,6 +119,23 @@ test('deleting an instance requires confirmation', async ({ mainWindow }) => {
   ).toHaveCount(0);
 });
 
+test('native notifications toggle is visible and defaults to enabled', async ({
+  mainWindow,
+}) => {
+  await mainWindow.locator('.header-settings-btn').click();
+  const toggle = mainWindow.locator('.settings-toggle input[type="checkbox"]');
+  await expect(toggle).toBeVisible();
+  await expect(toggle).toBeChecked();
+  await expect(
+    mainWindow.locator('.settings-toggle-title', { hasText: 'Native notifications' }),
+  ).toBeVisible();
+  // Toggle off, then on again.
+  await toggle.click();
+  await expect(toggle).not.toBeChecked();
+  await toggle.click();
+  await expect(toggle).toBeChecked();
+});
+
 test('clear all data button lives in settings with a confirm guard', async ({
   mainWindow,
 }) => {

--- a/tests/unit/formatNativeNotification.test.ts
+++ b/tests/unit/formatNativeNotification.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// formatNativeNotification is exported from notificationService, which imports
+// from 'electron' at top level. Mock electron before importing.
+vi.mock('electron', () => ({
+  app: { dock: { setBadge: vi.fn() } },
+  BrowserWindow: class {},
+  Notification: class {
+    static isSupported() {
+      return true;
+    }
+    constructor(_opts: unknown) {}
+    on() {}
+    show() {}
+  },
+}));
+
+import { formatNativeNotification } from '../../src/main/services/notificationService';
+
+describe('formatNativeNotification', () => {
+  it('prefixes title with [Nexus] and the instance name', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Work',
+      title: 'John Doe',
+      body: 'Lunch?',
+    });
+    expect(out.title).toBe('[Nexus] Work');
+  });
+
+  it('joins title and body with ": " when both present', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Personal',
+      title: 'Mom',
+      body: 'Call me back',
+    });
+    expect(out.body).toBe('Mom: Call me back');
+  });
+
+  it('uses body alone when title is empty', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Work',
+      title: '',
+      body: 'Ping from server',
+    });
+    expect(out.body).toBe('Ping from server');
+  });
+
+  it('uses title alone when body is empty', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Work',
+      title: 'New message',
+      body: '',
+    });
+    expect(out.body).toBe('New message');
+  });
+
+  it('returns empty body when both title and body are empty', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Work',
+      title: '',
+      body: '',
+    });
+    expect(out.body).toBe('');
+  });
+
+  it('trims whitespace on title and body', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Work',
+      title: '  Alice  ',
+      body: '  hi there  ',
+    });
+    expect(out.body).toBe('Alice: hi there');
+  });
+
+  it('handles unicode in both name and content', () => {
+    const out = formatNativeNotification({
+      instanceName: 'Работа',
+      title: '🎉',
+      body: 'Party time',
+    });
+    expect(out.title).toBe('[Nexus] Работа');
+    expect(out.body).toBe('🎉: Party time');
+  });
+
+  it('always returns a defined title and body', () => {
+    const out = formatNativeNotification({
+      instanceName: '',
+      title: '',
+      body: '',
+    });
+    expect(typeof out.title).toBe('string');
+    expect(typeof out.body).toBe('string');
+  });
+});

--- a/tests/unit/notificationService.test.ts
+++ b/tests/unit/notificationService.test.ts
@@ -1,10 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { dockMock } = vi.hoisted(() => ({ dockMock: { setBadge: vi.fn() } }));
-vi.mock('electron', () => ({
-  app: { dock: dockMock },
-  BrowserWindow: class {},
+const { dockMock, notifMock } = vi.hoisted(() => ({
+  dockMock: { setBadge: vi.fn() },
+  notifMock: {
+    show: vi.fn(),
+    on: vi.fn(),
+    lastOpts: null as any,
+  },
 }));
+
+vi.mock('electron', () => {
+  class FakeNotification {
+    constructor(opts: any) {
+      notifMock.lastOpts = opts;
+    }
+    static isSupported() {
+      return true;
+    }
+    show() {
+      notifMock.show();
+    }
+    on(event: string, handler: () => void) {
+      notifMock.on(event, handler);
+    }
+  }
+  return {
+    app: { dock: dockMock },
+    BrowserWindow: class {},
+    Notification: FakeNotification,
+  };
+});
 
 import { NotificationService } from '../../src/main/services/notificationService';
 import { Logger } from '../../src/main/core/logger';
@@ -17,6 +42,10 @@ class FakeWindowService {
   private destroyed = false;
   win = {
     isDestroyed: () => this.destroyed,
+    show: vi.fn(),
+    focus: vi.fn(),
+    restore: vi.fn(),
+    isMinimized: () => false,
     webContents: {
       send: (channel: string, payload: unknown) => this.sent.push({ channel, payload }),
     },
@@ -30,6 +59,32 @@ class FakeWindowService {
   }
 }
 
+class FakeSettingsService {
+  readonly name = 'settings';
+  state = {
+    activeInstanceId: null as string | null,
+    instances: [] as Array<{ id: string; moduleId: string; name: string }>,
+    themeId: 'nexus-dark',
+    notificationsEnabled: true as boolean,
+  };
+  init() {}
+  getInstance(id: string) {
+    return this.state.instances.find((i) => i.id === id);
+  }
+  setActive(id: string | null) {
+    this.state.activeInstanceId = id;
+  }
+  addFakeInstance(id: string, name: string) {
+    this.state.instances.push({ id, moduleId: id, name });
+  }
+}
+
+class FakeViewService {
+  readonly name = 'views';
+  activate = vi.fn();
+  init() {}
+}
+
 async function makeContainer() {
   const bus = new EventBus();
   const container = new ServiceContainer({
@@ -40,15 +95,24 @@ async function makeContainer() {
     isDev: false,
   });
   const win = new FakeWindowService();
+  const settings = new FakeSettingsService();
+  const views = new FakeViewService();
   const notifications = new NotificationService();
-  container.register(win as any).register(notifications);
+  container
+    .register(win as any)
+    .register(settings as any)
+    .register(views as any)
+    .register(notifications);
   await container.init();
-  return { container, bus, win, notifications };
+  return { container, bus, win, settings, views, notifications };
 }
 
 describe('NotificationService', () => {
   beforeEach(() => {
     dockMock.setBadge.mockClear();
+    notifMock.show.mockClear();
+    notifMock.on.mockClear();
+    notifMock.lastOpts = null;
   });
 
   it('broadcasts unread updates on the bus', async () => {
@@ -107,5 +171,60 @@ describe('NotificationService', () => {
     bus.emit('notification:update', { moduleId: 'whatsapp', count: 4 });
     bus.emit('notification:update', { moduleId: 'telegram', count: 1 });
     expect(notifications.all()).toEqual({ whatsapp: 4, telegram: 1 });
+  });
+
+  describe('native notifications', () => {
+    it('shows a native notification formatted with the instance name', async () => {
+      const { bus, settings } = await makeContainer();
+      settings.addFakeInstance('whatsapp', 'Work');
+      bus.emit('notification:native', {
+        instanceId: 'whatsapp',
+        title: 'John',
+        body: 'Lunch?',
+      });
+      expect(notifMock.show).toHaveBeenCalled();
+      expect(notifMock.lastOpts.title).toBe('[Nexus] Work');
+      expect(notifMock.lastOpts.body).toBe('John: Lunch?');
+    });
+
+    it('skips native notifications when the setting is disabled', async () => {
+      const { bus, settings } = await makeContainer();
+      settings.state.notificationsEnabled = false;
+      settings.addFakeInstance('whatsapp', 'Work');
+      bus.emit('notification:native', {
+        instanceId: 'whatsapp',
+        title: 'John',
+        body: 'Lunch?',
+      });
+      expect(notifMock.show).not.toHaveBeenCalled();
+    });
+
+    it('ignores events for unknown instances', async () => {
+      const { bus } = await makeContainer();
+      bus.emit('notification:native', {
+        instanceId: 'ghost',
+        title: 'hi',
+        body: 'there',
+      });
+      expect(notifMock.show).not.toHaveBeenCalled();
+    });
+
+    it('click handler focuses window and activates the instance', async () => {
+      const { bus, settings, views, win } = await makeContainer();
+      settings.addFakeInstance('whatsapp', 'Work');
+      bus.emit('notification:native', {
+        instanceId: 'whatsapp',
+        title: 'John',
+        body: 'Lunch?',
+      });
+      // Capture the click handler and invoke it.
+      const clickCall = notifMock.on.mock.calls.find((c: any) => c[0] === 'click');
+      expect(clickCall).toBeTruthy();
+      const clickHandler = clickCall![1];
+      clickHandler();
+      expect(win.win.focus).toHaveBeenCalled();
+      expect(views.activate).toHaveBeenCalledWith('whatsapp');
+      expect(settings.state.activeInstanceId).toBe('whatsapp');
+    });
   });
 });

--- a/tests/unit/settingsService.test.ts
+++ b/tests/unit/settingsService.test.ts
@@ -203,6 +203,29 @@ describe('SettingsService', () => {
     await s.dispose();
   });
 
+  it('notificationsEnabled defaults to true and round-trips through disk', async () => {
+    const s1 = new SettingsService();
+    await s1.init(makeCtx(tmp));
+    expect(s1.state.notificationsEnabled).toBe(true);
+    s1.setNotificationsEnabled(false);
+    expect(s1.state.notificationsEnabled).toBe(false);
+    await s1.dispose();
+
+    const s2 = new SettingsService();
+    await s2.init(makeCtx(tmp));
+    expect(s2.state.notificationsEnabled).toBe(false);
+    await s2.dispose();
+  });
+
+  it('setNotificationsEnabled is a no-op when value unchanged', async () => {
+    const s = new SettingsService();
+    await s.init(makeCtx(tmp));
+    const before = s.state;
+    s.setNotificationsEnabled(true); // already default
+    expect(s.state).toBe(before);
+    await s.dispose();
+  });
+
   it('clearAll resets every field to defaults and removes the state file', async () => {
     const s = new SettingsService();
     await s.init(makeCtx(tmp));


### PR DESCRIPTION
Intercept every enabled instance's window.Notification calls and present them as native macOS / Windows notifications branded with the Nexus prefix and the instance's user-chosen name. Works for all instances simultaneously because non-active WebContentsViews stay alive in the background.

Interception pipeline
- Each service view still has contextIsolation: true + sandbox: true, so the preload runs in an isolated world and can't touch window.Notification directly. Instead:
    1. ViewService calls session.setPreloads([notifyPreload.js]) on the instance session so every frame loads the Nexus preload alongside any module-specific preload.
    2. On dom-ready, ViewService.executeJavaScript injects a main-world shim (src/main/services/notifications/mainWorldShim.ts) that replaces window.Notification. The shim dispatches a CustomEvent('nexus-notify', { detail }) on document — DOM events cross the contextIsolation boundary because the DOM itself is shared.
    3. notifyPreload.ts listens for 'nexus-notify' on document, coerces/ truncates the payload, and forwards via ipcRenderer.send.
    4. ViewService catches webContents.ipc.on('nexus:notify:show', ...) and emits a 'notification:native' bus event.
    5. NotificationService.showNative receives it, looks up the instance by id, formats a branded title/body, and constructs a native Electron Notification.
- Shim is idempotent (guard flag), safe to re-inject on reload, and stubs out .close() / .onclick / .addEventListener so legacy code that holds a Notification reference doesn't crash.
- Notification.requestPermission() and Notification.permission in the shim always return 'granted' — the user implicitly granted permission by using the service in Nexus.

Format
- Title: "[Nexus] <instance name>" (e.g. "[Nexus] Work")
- Body:  "<original title>: <original body>" when both present, otherwise whichever is non-empty.
- Subtitle: "Nexus" on macOS so the branding is visible below the title.
- Click: focuses the Nexus window (restoring from minimized if needed) and activates the instance that fired the notification.

Settings
- New AppState.notificationsEnabled (defaults to true) persisted in nexus-state.json.
- IPC channel nexus:notify:set-enabled + preload setNotificationsEnabled and store action setNotificationsEnabled.
- New "Native notifications" toggle at the top of Settings → Modules, with description that shows the exact format users will see and explains click-to-focus behavior.
- NotificationService.showNative is gated on the flag AND on Electron.Notification.isSupported() per-platform.

Tests (136 unit + 24 E2E, all green)
- New formatNativeNotification.test.ts (8 tests) covers:
    - [Nexus] prefix always applied
    - title+body joined with ": "
    - body alone when title empty, title alone when body empty
    - both empty case
    - whitespace trimming
    - unicode (Cyrillic, emoji)
- notificationService.test.ts gained FakeSettingsService + FakeViewService fakes and 4 new native-notification tests:
    - format the native payload with [Nexus] <name>
    - skip when notificationsEnabled = false
    - ignore unknown instances
    - click handler focuses window + activates instance
- settingsService.test.ts: notificationsEnabled round-trips through disk + no-op on unchanged value.
- E2E: new settings toggle is visible, checked by default, and responds to clicks (off → on round trip).

No new npm dependencies — Electron's built-in Notification handles everything. Works on macOS, Windows, and modern Linux desktop envs that expose org.freedesktop.Notifications.