### PR TITLE
fix: sidebar highlight out of sync after notification click

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -73,6 +73,11 @@ const api = {
     ipcRenderer.on('nexus:menu', listener);
     return () => ipcRenderer.removeListener('nexus:menu', listener);
   },
+  onInstanceActivated: (cb: (instanceId: string) => void): (() => void) => {
+    const listener = (_: unknown, payload: { instanceId: string }) => cb(payload.instanceId);
+    ipcRenderer.on(IPC.INSTANCE_ACTIVATED, listener);
+    return () => ipcRenderer.removeListener(IPC.INSTANCE_ACTIVATED, listener);
+  },
   getAllUnread: (): Promise<Record<string, number>> => invoke(IPC.UNREAD_ALL),
   setNotificationsEnabled: (enabled: boolean): Promise<void> =>
     invoke(IPC.NOTIFY_SET_ENABLED, enabled),

--- a/src/main/services/ipcService.ts
+++ b/src/main/services/ipcService.ts
@@ -29,6 +29,8 @@ export class IpcService implements Service {
   readonly name = 'ipc';
   private router!: IpcRouter;
   private logger!: Logger;
+  /** Teardown fns for external subscriptions (e.g. bus listeners). */
+  private teardowns: Array<() => void> = [];
 
   async init(ctx: ServiceContext): Promise<void> {
     this.logger = ctx.logger.child('ipc');
@@ -458,9 +460,31 @@ export class IpcService implements Service {
         await community.install(moduleId, overwrite === true);
       },
     });
+
+    // Forward `instance:activated` bus events to the main renderer window so
+    // the sidebar's active-instance highlight stays in sync no matter what
+    // triggered the activation (sidebar click round-trips through the same
+    // event, but notification click and command-palette activate also fire
+    // it from main without renderer involvement).
+    this.teardowns.push(
+      ctx.bus.on('instance:activated', ({ instanceId }) => {
+        const win = windowSvc.getWindow();
+        if (win && !win.isDestroyed()) {
+          win.webContents.send(IPC.INSTANCE_ACTIVATED, { instanceId });
+        }
+      }),
+    );
   }
 
   dispose(): void {
     this.router.dispose();
+    for (const fn of this.teardowns) {
+      try {
+        fn();
+      } catch {
+        /* ignore */
+      }
+    }
+    this.teardowns = [];
   }
 }

--- a/src/renderer/nexus.d.ts
+++ b/src/renderer/nexus.d.ts
@@ -60,6 +60,7 @@ declare global {
 
       onUnread(cb: (update: UnreadUpdate) => void): () => void;
       onMenu(cb: (event: string) => void): () => void;
+      onInstanceActivated(cb: (instanceId: string) => void): () => void;
       getAllUnread(): Promise<Record<string, number>>;
       setNotificationsEnabled(enabled: boolean): Promise<void>;
       setNotificationSound(enabled: boolean): Promise<void>;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -213,6 +213,16 @@ export const useNexus = create<NexusStore>((set, get) => ({
       window.nexus.onUnread((update) => {
         set((s) => ({ unread: { ...s.unread, [update.moduleId]: update.count } }));
       });
+
+      // Sync the sidebar highlight whenever main activates an instance for
+      // any reason (notification click, command palette, etc.). The sidebar
+      // click path also fires this event but already updates state itself
+      // via refreshComposite; a duplicate refresh is harmless.
+      window.nexus.onInstanceActivated(async (instanceId) => {
+        // Cheap path first: just update activeInstanceId in place. Avoids
+        // a full IPC round-trip on every notification click.
+        set((s) => ({ state: { ...s.state, activeInstanceId: instanceId } }));
+      });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err), ready: true });
     }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,6 +53,13 @@ export const IPC = {
   MODULES_OPEN_DIR: 'nexus:modules:open-dir',
   MODULES_RELOAD: 'nexus:modules:reload',
   INSTANCES_ACTIVATE: 'nexus:instances:activate',
+  /**
+   * Push-event channel: main → renderer. Fires whenever the active instance
+   * changes for any reason (sidebar click, notification click, command
+   * palette, etc.). Renderer listens to keep its sidebar highlight in sync
+   * with whatever main has activated.
+   */
+  INSTANCE_ACTIVATED: 'nexus:instance:activated',
   INSTANCES_ADD: 'nexus:instances:add',
   INSTANCES_REMOVE: 'nexus:instances:remove',
   INSTANCES_RENAME: 'nexus:instances:rename',


### PR DESCRIPTION
## Summary

Fixes a stale-highlight bug: clicking a native OS notification opened the right webview but left the sidebar's "active" highlight on the previous instance.

## Root cause

When the user clicks a native notification, \`NotificationService.onclick\` correctly calls both \`views.activate(id)\` and \`profiles.setActive(id)\`, and \`ViewService\` emits \`instance:activated\` on the main-process eventBus. But nothing was forwarding that bus event to the renderer — so the renderer's \`state.activeInstanceId\` stayed stale.

Sidebar clicks worked because they round-trip through the renderer's own \`activateInstance\` action, which calls \`refreshComposite()\` and overwrites the Zustand state from scratch.

## Fix

Wire a main → renderer bridge for the bus event so the renderer hears about activations no matter what triggered them.

- **New IPC channel** \`nexus:instance:activated\` (push, main → renderer).
- **\`IpcService\`** subscribes to bus \`instance:activated\` on init; forwards to the main window via \`webContents.send\`. Tracks the subscription in a new \`teardowns\` array so \`dispose()\` unhooks it cleanly.
- **\`preload.ts\`** exposes \`window.nexus.onInstanceActivated(cb)\`.
- **Renderer \`store.init()\`** subscribes and updates \`state.activeInstanceId\` in place. No full \`refreshComposite\` needed — only that one field changes — and the sidebar-click path still does a full refresh for everything else.

## Audit

Checked all other \`bus.emit\` callsites to make sure this wasn't a wider class of bug. \`instance:activated\` was the only orphan event — every other emit is either renderer-initiated (round-trips through IPC) or already has a forwarding path (\`unread:update\`, etc.).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test\` — 178/178 passing
- [x] \`npm run build\` — renderer + main both clean
- [ ] Manual smoke: open Nexus, add at least 2 instances, switch to Telegram, trigger a WhatsApp notification, click it → sidebar highlight should jump to WhatsApp (not stay on Telegram)

No automated test added — the bug is purely renderer↔main IPC wiring and the project doesn't yet have an integration-test harness for that surface. The four edits are small enough that the manual smoke test is the right level of validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)