### PR TITLE
feat: crash recovery overlay for unresponsive instances

### DIFF
--- a/src/main/core/eventBus.ts
+++ b/src/main/core/eventBus.ts
@@ -13,6 +13,7 @@ export interface NexusEvents {
   'view:suspended': { suspended: boolean };
   'view:ready': { instanceId: string };
   'view:load-failed': { instanceId: string; error: string };
+  'view:crashed': { instanceId: string; reason: string };
   'notification:update': UnreadUpdate;
   'notification:native': {
     instanceId: string;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -78,6 +78,14 @@ const api = {
     ipcRenderer.on(IPC.INSTANCE_ACTIVATED, listener);
     return () => ipcRenderer.removeListener(IPC.INSTANCE_ACTIVATED, listener);
   },
+  onViewCrashed: (
+    cb: (info: { instanceId: string; reason: string }) => void,
+  ): (() => void) => {
+    const listener = (_: unknown, payload: { instanceId: string; reason: string }) =>
+      cb(payload);
+    ipcRenderer.on(IPC.VIEW_CRASHED, listener);
+    return () => ipcRenderer.removeListener(IPC.VIEW_CRASHED, listener);
+  },
   getAllUnread: (): Promise<Record<string, number>> => invoke(IPC.UNREAD_ALL),
   setNotificationsEnabled: (enabled: boolean): Promise<void> =>
     invoke(IPC.NOTIFY_SET_ENABLED, enabled),

--- a/src/main/services/ipcService.ts
+++ b/src/main/services/ipcService.ts
@@ -474,6 +474,17 @@ export class IpcService implements Service {
         }
       }),
     );
+
+    // Forward `view:crashed` bus events so the renderer can show the
+    // CrashOverlay over the affected instance's content area.
+    this.teardowns.push(
+      ctx.bus.on('view:crashed', ({ instanceId, reason }) => {
+        const win = windowSvc.getWindow();
+        if (win && !win.isDestroyed()) {
+          win.webContents.send(IPC.VIEW_CRASHED, { instanceId, reason });
+        }
+      }),
+    );
   }
 
   dispose(): void {

--- a/src/main/services/viewService.ts
+++ b/src/main/services/viewService.ts
@@ -321,6 +321,24 @@ export class ViewService implements Service {
       this.ctx.bus.emit('view:load-failed', { instanceId: instance.id, error: desc });
     });
 
+    // Renderer-process crash detection. Fires when the embedded web page's
+    // renderer process exits abnormally (OOM kill, segfault in V8, the page
+    // calling process.crash(), etc.). Without this hook the user just sees
+    // a frozen webview; with it, the renderer's CrashOverlay shows over the
+    // content area with a Reload button.
+    view.webContents.on('render-process-gone', (_e, details) => {
+      // `clean-exit` is a normal teardown (e.g. on view.webContents.close()).
+      // Only flag the abnormal exits.
+      if (details.reason === 'clean-exit') return;
+      this.logger.warn(
+        `renderer for ${instance.id} died: ${details.reason} (exitCode ${details.exitCode})`,
+      );
+      this.ctx.bus.emit('view:crashed', {
+        instanceId: instance.id,
+        reason: details.reason,
+      });
+    });
+
     const strategy = this.strategyFactory.create(
       manifest.notifications ?? { kind: 'title' },
     );

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { useNexus } from './store';
 import { Sidebar } from './components/Sidebar';
 import { ContentArea } from './components/ContentArea';
+import { CrashOverlay } from './components/CrashOverlay';
 import { SettingsPanel } from './components/SettingsPanel';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { AppHeader } from './components/AppHeader';
@@ -137,6 +138,7 @@ export function App() {
         <AccountManager />
         <CommandPalette />
         <ConfirmDialog />
+        <CrashOverlay />
       </div>
     </ErrorBoundary>
   );

--- a/src/renderer/components/CrashOverlay.tsx
+++ b/src/renderer/components/CrashOverlay.tsx
@@ -1,0 +1,66 @@
+import { useNexus } from '../store';
+import { useOverlay } from '../hooks/useOverlay';
+
+/**
+ * Renders over the content area when the currently-active instance's
+ * renderer process has crashed. Offers the user a clear path to either
+ * reload the instance (respawning its renderer) or dismiss the overlay
+ * and continue using other instances.
+ *
+ * Uses the global overlay-count hook so the underlying WebContentsView
+ * is moved offscreen while we show — otherwise the native view would
+ * obscure our HTML.
+ */
+export function CrashOverlay(): JSX.Element | null {
+  const activeId = useNexus((s) => s.state.activeInstanceId);
+  const crashed = useNexus((s) => s.crashedInstances);
+  const instances = useNexus((s) => s.state.instances);
+  const reloadCrashed = useNexus((s) => s.reloadCrashedInstance);
+  const dismiss = useNexus((s) => s.dismissCrash);
+
+  // Only show when the *active* instance is crashed. Background instances
+  // that crash are silently tracked and surface when the user activates
+  // them.
+  const crashInfo = activeId ? crashed[activeId] : undefined;
+  const isVisible = !!crashInfo && !!activeId;
+
+  // Always call useOverlay so the hook order stays stable across renders,
+  // but pass a falsy flag when we don't actually want to suspend.
+  useOverlay(isVisible);
+
+  if (!isVisible || !activeId) return null;
+
+  const instance = instances.find((i) => i.id === activeId);
+  const instanceName = instance?.name ?? 'This instance';
+
+  return (
+    <div className="crash-overlay" role="alert">
+      <div className="crash-overlay-card">
+        <div className="crash-overlay-icon">⚠️</div>
+        <h2 className="crash-overlay-title">{instanceName} stopped responding</h2>
+        <p className="crash-overlay-reason">
+          The embedded web view crashed
+          {crashInfo.reason && crashInfo.reason !== 'crashed'
+            ? ` (${crashInfo.reason})`
+            : ''}
+          . Reload to start it again, or dismiss and switch to another instance.
+        </p>
+        <div className="crash-overlay-actions">
+          <button
+            type="button"
+            className="crash-overlay-reload"
+            onClick={() => {
+              void reloadCrashed(activeId);
+            }}
+            autoFocus
+          >
+            Reload
+          </button>
+          <button type="button" className="crash-overlay-dismiss" onClick={() => dismiss(activeId)}>
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/nexus.d.ts
+++ b/src/renderer/nexus.d.ts
@@ -61,6 +61,9 @@ declare global {
       onUnread(cb: (update: UnreadUpdate) => void): () => void;
       onMenu(cb: (event: string) => void): () => void;
       onInstanceActivated(cb: (instanceId: string) => void): () => void;
+      onViewCrashed(
+        cb: (info: { instanceId: string; reason: string }) => void,
+      ): () => void;
       getAllUnread(): Promise<Record<string, number>>;
       setNotificationsEnabled(enabled: boolean): Promise<void>;
       setNotificationSound(enabled: boolean): Promise<void>;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -56,6 +56,14 @@ interface NexusStore {
   currentProfile: ProfileSummary | null;
   accountManagerOpen: boolean;
 
+  /**
+   * Set of instance ids whose renderer process has crashed since this
+   * Nexus session started. The CrashOverlay reads this to decide whether
+   * to show the recovery panel for the active instance. Cleared per
+   * entry on successful reload or explicit dismiss.
+   */
+  crashedInstances: Record<string, { reason: string }>;
+
   init(): Promise<void>;
   activateInstance(instanceId: string): Promise<void>;
   addInstance(moduleId: string): Promise<ModuleInstance>;
@@ -125,6 +133,11 @@ interface NexusStore {
   // on unmount; a single App-level effect suspends views while count > 0.
   pushOverlay(): void;
   popOverlay(): void;
+
+  /** Reload a crashed instance and clear its crashed flag. */
+  reloadCrashedInstance(instanceId: string): Promise<void>;
+  /** Dismiss the crash overlay for an instance without reloading. */
+  dismissCrash(instanceId: string): void;
 }
 
 const EMPTY_PROFILE_STATE: ProfileState = {
@@ -184,6 +197,7 @@ export const useNexus = create<NexusStore>((set, get) => ({
   profiles: [],
   currentProfile: null,
   accountManagerOpen: false,
+  crashedInstances: {},
 
   async init() {
     try {
@@ -222,6 +236,14 @@ export const useNexus = create<NexusStore>((set, get) => ({
         // Cheap path first: just update activeInstanceId in place. Avoids
         // a full IPC round-trip on every notification click.
         set((s) => ({ state: { ...s.state, activeInstanceId: instanceId } }));
+      });
+
+      // Track renderer-process crashes so the CrashOverlay can show over
+      // the affected instance's content area.
+      window.nexus.onViewCrashed(({ instanceId, reason }) => {
+        set((s) => ({
+          crashedInstances: { ...s.crashedInstances, [instanceId]: { reason } },
+        }));
       });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err), ready: true });
@@ -547,5 +569,38 @@ export const useNexus = create<NexusStore>((set, get) => ({
 
   popOverlay() {
     set((s) => ({ overlayCount: Math.max(0, s.overlayCount - 1) }));
+  },
+
+  async reloadCrashedInstance(instanceId) {
+    // The crashed flag is cleared optimistically. If the new render
+    // process also crashes, render-process-gone fires again and we'll
+    // re-add it to the set.
+    set((s) => {
+      const next = { ...s.crashedInstances };
+      delete next[instanceId];
+      return { crashedInstances: next };
+    });
+    // The main process's reloadActiveInstance only reloads whichever
+    // view is currently active. Make sure this one is active before
+    // reloading (no-op if it already is).
+    try {
+      await window.nexus.activateInstance(instanceId);
+      await window.nexus.reloadActiveInstance();
+    } catch (err) {
+      // If reload itself fails, re-flag so the overlay reappears with
+      // the new error string.
+      const reason = err instanceof Error ? err.message : String(err);
+      set((s) => ({
+        crashedInstances: { ...s.crashedInstances, [instanceId]: { reason } },
+      }));
+    }
+  },
+
+  dismissCrash(instanceId) {
+    set((s) => {
+      const next = { ...s.crashedInstances };
+      delete next[instanceId];
+      return { crashedInstances: next };
+    });
   },
 }));

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1973,3 +1973,79 @@ img.sidebar-logo.app-icon-img {
   font-size: 12px;
   color: var(--nx-badge);
 }
+
+/* ---------------- Crash recovery overlay ---------------- */
+
+.crash-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 1000;
+  padding: 24px;
+}
+
+.crash-overlay-card {
+  max-width: 460px;
+  background: var(--nx-bg);
+  color: var(--nx-text);
+  border: 1px solid var(--nx-border);
+  border-radius: 10px;
+  padding: 28px;
+  text-align: center;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+}
+
+.crash-overlay-icon {
+  font-size: 32px;
+  line-height: 1;
+  margin-bottom: 8px;
+}
+
+.crash-overlay-title {
+  margin: 4px 0 8px 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.crash-overlay-reason {
+  margin: 0 0 20px 0;
+  font-size: 13px;
+  color: var(--nx-text-muted);
+  line-height: 1.4;
+}
+
+.crash-overlay-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.crash-overlay-reload {
+  background: var(--nx-accent);
+  color: var(--nx-accent-fg);
+  border: 1px solid var(--nx-accent);
+  border-radius: 6px;
+  padding: 8px 20px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.crash-overlay-reload:hover {
+  filter: brightness(1.1);
+}
+
+.crash-overlay-dismiss {
+  background: transparent;
+  color: var(--nx-text);
+  border: 1px solid var(--nx-border);
+  border-radius: 6px;
+  padding: 8px 20px;
+  cursor: pointer;
+}
+
+.crash-overlay-dismiss:hover {
+  background: var(--nx-sidebar-hover);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -65,6 +65,13 @@ export const IPC = {
   INSTANCES_RENAME: 'nexus:instances:rename',
   INSTANCES_RELOAD_ACTIVE: 'nexus:instances:reload-active',
   INSTANCES_SET_MUTED: 'nexus:instances:set-muted',
+  /**
+   * Push-event channel: main → renderer. Fires when a WebContentsView's
+   * renderer process dies (`render-process-gone` event). Renderer shows
+   * the CrashOverlay component over the affected instance's content area
+   * so the user can reload or dismiss.
+   */
+  VIEW_CRASHED: 'nexus:view:crashed',
   THEMES_LIST: 'nexus:themes:list',
   THEMES_SET: 'nexus:themes:set',
   THEMES_SAVE: 'nexus:themes:save',


### PR DESCRIPTION
## Summary

When an embedded webview's renderer process dies (OOM kill, V8 segfault, malicious page calling \`process.crash()\`, a runaway memory leak), Nexus previously just showed a frozen view with no signal to the user. This PR adds an HTML overlay over the affected instance with **Reload** and **Dismiss** buttons.

> **Branch base:** \`fix/notification-sidebar-sync\` — this stacks on the open PR #6 so the teardowns + bus-forwarding patterns added there are reused here. Merge #6 first.

## Mechanism

Same main → bus → IPC → renderer pattern as the notification/sidebar sync fix:

1. **\`ViewService\`** attaches \`webContents.on('render-process-gone', …)\` to every view at creation. Filters out clean exits. Emits a new \`view:crashed\` bus event with \`{instanceId, reason}\`.
2. **\`IpcService\`** subscribes to the bus event (alongside \`instance:activated\`) and forwards to the main renderer window via the new \`nexus:view:crashed\` IPC channel.
3. **\`preload.ts\`** exposes \`window.nexus.onViewCrashed(cb)\`.
4. **Renderer store** tracks \`crashedInstances: Record<id, {reason}>\` and gets two new actions: \`reloadCrashedInstance(id)\` and \`dismissCrash(id)\`.
5. **New \`CrashOverlay\` component** mounted globally in \`App.tsx\`. Shows only when the *active* instance is in the crashed map. Uses the existing \`useOverlay()\` hook so the underlying WebContentsView is moved offscreen while the overlay is visible — without that, the native Chromium layer would obscure our HTML.

## Design choices

- **No auto-reload.** Crash loops are worse than a stuck panel; user controls when to retry.
- **Background instances that crash are silently tracked** and the overlay only shows when the user activates them. Avoids interrupting whatever else they're doing.
- **Dismiss removes the entry entirely** — re-activating the instance after dismissing won't re-show the overlay until it crashes again.
- **Optimistic flag clearing on Reload.** If the reload itself fails, the action re-flags with the new error string so the overlay reappears with a useful message.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test\` — 178/178 passing
- [x] \`npm run build\` — renderer + main both clean
- [ ] Manual smoke: open an instance, open its devtools, type \`process.crash()\`. Overlay should appear within ~200ms. Click Reload — fresh renderer spawns, overlay disappears. Try Dismiss instead — overlay hides, you can switch to another instance.
- [ ] Manual smoke: trigger a crash on a *background* instance (open it, switch away, then crash). No overlay shows until you activate that instance, at which point it appears.

No automated test — the same IPC integration gap as the prior PR. The change is small enough that manual smoke is the right level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)