### PR TITLE
feat: export and import Nexus preferences

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -54,6 +54,10 @@ const api = {
   importThemePack: (): Promise<
     { canceled: true } | { canceled: false; added: Theme[]; themes: Theme[] }
   > => invoke(IPC.THEMES_IMPORT_PACK),
+  exportPrefs: (): Promise<{ canceled: true } | { canceled: false; path: string }> =>
+    invoke(IPC.PREFS_EXPORT),
+  importPrefs: (): Promise<{ canceled: true } | { canceled: false; path: string }> =>
+    invoke(IPC.PREFS_IMPORT),
 
   getState: (): Promise<AppState> => invoke(IPC.STATE_GET),
   setContentBounds: (bounds: Bounds): Promise<void> => invoke(IPC.LAYOUT_SET_BOUNDS, bounds),

--- a/src/main/services/ipcService.ts
+++ b/src/main/services/ipcService.ts
@@ -3,6 +3,7 @@ import { app, dialog, BrowserWindow } from 'electron';
 import * as fs from 'fs/promises';
 import { IPC } from '../../shared/types';
 import {
+  appStateSchema,
   boundsSchema,
   moduleIdSchema,
   themeIdSchema,
@@ -192,6 +193,87 @@ export class IpcService implements Service {
     });
 
     this.router.register(IPC.STATE_GET, { handler: () => settings.state });
+
+    // Preferences export/import. Scoped to the global app state only —
+    // themes have their own dedicated export/import flow, and profile /
+    // instance / session data is deliberately NOT included (no logins
+    // travel between machines; users sign in fresh after restore).
+    this.router.register(IPC.PREFS_EXPORT, {
+      handler: async () => {
+        const win = windowSvc.getWindow();
+        const parent = win && !win.isDestroyed() ? win : (BrowserWindow.getFocusedWindow() ?? undefined);
+        const result = await dialog.showSaveDialog(parent as BrowserWindow, {
+          title: 'Export Nexus preferences',
+          defaultPath: `nexus-prefs-${new Date().toISOString().slice(0, 10)}.json`,
+          filters: [{ name: 'Nexus preferences', extensions: ['json'] }],
+        });
+        if (result.canceled || !result.filePath) {
+          return { canceled: true as const };
+        }
+        const bundle = {
+          $schema: 'nexus-prefs' as const,
+          version: 1 as const,
+          exportedAt: new Date().toISOString(),
+          appVersion: app.getVersion(),
+          appState: settings.state,
+        };
+        await fs.writeFile(result.filePath, JSON.stringify(bundle, null, 2), 'utf8');
+        return { canceled: false as const, path: result.filePath };
+      },
+    });
+
+    this.router.register(IPC.PREFS_IMPORT, {
+      handler: async () => {
+        const win = windowSvc.getWindow();
+        const parent = win && !win.isDestroyed() ? win : (BrowserWindow.getFocusedWindow() ?? undefined);
+        const result = await dialog.showOpenDialog(parent as BrowserWindow, {
+          title: 'Import Nexus preferences',
+          properties: ['openFile'],
+          filters: [{ name: 'Nexus preferences', extensions: ['json'] }],
+        });
+        if (result.canceled || result.filePaths.length === 0) {
+          return { canceled: true as const };
+        }
+        const filePath = result.filePaths[0];
+        const raw = await fs.readFile(filePath, 'utf8');
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          throw new Error('selected file is not valid JSON');
+        }
+        const bundleSchema = z.object({
+          $schema: z.literal('nexus-prefs').optional(),
+          version: z.literal(1),
+          exportedAt: z.string().optional(),
+          appVersion: z.string().optional(),
+          appState: appStateSchema,
+        });
+        const validated = bundleSchema.safeParse(parsed);
+        if (!validated.success) {
+          throw new Error(
+            'preferences file does not match the expected shape (was it written by an older Nexus, or hand-edited?)',
+          );
+        }
+        // Activate-profile + global-shortcut + window-state come from the
+        // CURRENT machine; importing them is more annoying than useful.
+        // Strip them so the user keeps their existing profile selection
+        // and window position. Theme + notification + sidebar prefs do
+        // come across.
+        const { activeProfileId: _activeProfileId, windowState: _windowState, ...importable } =
+          validated.data.appState;
+        void _activeProfileId;
+        void _windowState;
+        settings.update(importable);
+        // Reload the renderer so it picks up the new state cleanly. The
+        // window stays where it is (we kept windowState) so the reload
+        // is visually minimal.
+        if (win && !win.isDestroyed()) {
+          win.webContents.reloadIgnoringCache();
+        }
+        return { canceled: false as const, path: filePath };
+      },
+    });
 
     this.router.register(IPC.LAYOUT_SET_BOUNDS, {
       input: boundsSchema,

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -426,6 +426,62 @@ export function SettingsPanel({ onClose }: Props) {
                 </dl>
               </div>
 
+              <div className="settings-backup">
+                <h3>Backup</h3>
+                <p className="editor-hint">
+                  Export your Nexus <strong>preferences</strong> (theme choice, notification
+                  settings, DND, sidebar width, etc.) to a JSON file you can restore on
+                  another machine. Themes have their own export under the Themes tab.
+                  Account logins are not included — sign in to each instance fresh on the
+                  new machine.
+                </p>
+                <div className="row-actions">
+                  <button
+                    onClick={async () => {
+                      try {
+                        const res = await window.nexus.exportPrefs();
+                        if (!res.canceled) {
+                          setNotifFlash(`Exported preferences to ${res.path}`);
+                          setTimeout(() => setNotifFlash(null), 4000);
+                        }
+                      } catch (err) {
+                        setNotifFlash(
+                          'Export failed: ' + (err instanceof Error ? err.message : String(err)),
+                        );
+                        setTimeout(() => setNotifFlash(null), 5000);
+                      }
+                    }}
+                  >
+                    Export preferences…
+                  </button>
+                  <button
+                    onClick={async () => {
+                      const ok = await showConfirm({
+                        title: 'Import preferences?',
+                        message:
+                          'This will replace your current Nexus preferences (theme, notifications, sidebar width, etc.) with those from the selected file. Your accounts and themes are not affected. Nexus will reload after importing.',
+                        confirmLabel: 'Choose file…',
+                      });
+                      if (!ok) return;
+                      try {
+                        await window.nexus.importPrefs();
+                        // On success, main reloads the renderer — we won't reach
+                        // anything after this. If user cancels the file picker,
+                        // we fall through silently.
+                      } catch (err) {
+                        setNotifFlash(
+                          'Import failed: ' + (err instanceof Error ? err.message : String(err)),
+                        );
+                        setTimeout(() => setNotifFlash(null), 5000);
+                      }
+                    }}
+                  >
+                    Import preferences…
+                  </button>
+                </div>
+                {notifFlash && <p className="settings-flash">{notifFlash}</p>}
+              </div>
+
               <div className="danger-zone">
                 <h3>Danger zone</h3>
                 <p>

--- a/src/renderer/nexus.d.ts
+++ b/src/renderer/nexus.d.ts
@@ -51,6 +51,8 @@ declare global {
       importThemePack(): Promise<
         { canceled: true } | { canceled: false; added: Theme[]; themes: Theme[] }
       >;
+      exportPrefs(): Promise<{ canceled: true } | { canceled: false; path: string }>;
+      importPrefs(): Promise<{ canceled: true } | { canceled: false; path: string }>;
 
       getState(): Promise<AppState>;
       setContentBounds(bounds: Bounds): Promise<void>;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2049,3 +2049,25 @@ img.sidebar-logo.app-icon-img {
 .crash-overlay-dismiss:hover {
   background: var(--nx-sidebar-hover);
 }
+
+/* Settings — Backup section */
+.settings-backup {
+  margin-top: 24px;
+  padding: 16px;
+  border: 1px solid var(--nx-border);
+  border-radius: 8px;
+}
+
+.settings-backup h3 {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+}
+
+.settings-flash {
+  margin-top: 10px;
+  padding: 6px 10px;
+  font-size: 12px;
+  background: var(--nx-sidebar-hover);
+  border-radius: 4px;
+  color: var(--nx-text);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -111,6 +111,8 @@ export const IPC = {
   UPDATER_INSTALL: 'nexus:updater:install',
   UPDATER_STATUS: 'nexus:updater:status',
   APP_VERSION: 'nexus:app:version',
+  PREFS_EXPORT: 'nexus:prefs:export',
+  PREFS_IMPORT: 'nexus:prefs:import',
   COMMUNITY_MODULES_LIST: 'nexus:community-modules:list',
   COMMUNITY_MODULES_INSTALL: 'nexus:community-modules:install',
 } as const;


### PR DESCRIPTION
## Summary

Adds a **Backup** section to Settings → General with **Export preferences…** and **Import preferences…** buttons. Lets users back up Nexus app-level prefs (theme choice, notification settings, DND, sidebar width, etc.) to a JSON file and restore them on another machine — without copying the entire \`~/Library/Application Support\` folder.

> **Branch base:** \`feat/crash-recovery\` — stacks on PR #7 (which stacks on #6). Merge in order.

## Scope (deliberately narrow for v1)

**Included** in the bundle:
- Theme choice, sidebar compact/width, all notification settings, DND schedule, launch-at-login, close-to-tray, global shortcut.

**Excluded** by design:
- Themes — already have their own export/import under the Themes tab.
- \`activeProfileId\` and \`windowState\` — machine-specific; importing them between machines is more annoying than useful.
- Profiles, instance lists, session data — touching these would risk wiping logins. A future v2 with encrypted session export could enable cross-machine login migration; v1 keeps things simple and risk-free.

## Bundle format

\`\`\`json
{
  "\$schema": "nexus-prefs",
  "version": 1,
  "exportedAt": "2026-04-22T10:00:00.000Z",
  "appVersion": "1.3.2",
  "appState": { /* ...validated against appStateSchema... */ }
}
\`\`\`

Validation happens via the existing \`appStateSchema\`, so a malformed or hand-edited file fails cleanly with a user-visible error rather than corrupting settings.

## Implementation

- Two new IPC channels: \`nexus:prefs:export\`, \`nexus:prefs:import\`.
- Export: \`showSaveDialog\` with timestamped default filename (\`nexus-prefs-YYYY-MM-DD.json\`).
- Import: \`showOpenDialog\`, validate, strip machine-specific fields, merge into settings, reload renderer. Reload is required so the in-memory store picks up the new theme/sidebar config cleanly.
- UI confirms before importing with a clear "this will replace your preferences" message.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test\` — 178/178 passing
- [x] \`npm run build\` — renderer + main both clean
- [ ] Manual smoke: change theme to "Solarized" (or whatever), set DND 22:00–08:00, drag sidebar narrow, export. Open the JSON file — confirm those values are there. Change settings to something else. Import the file — settings should snap back to what was exported; window position should NOT move.
- [ ] Manual smoke: try importing a malformed file (e.g. \`echo '{}' > bad.json\`) — should show "does not match expected shape" error, no state changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)