### PR TITLE
feat: surface per-module load errors in Settings → Modules

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -9,6 +9,7 @@ import type {
   SidebarLayout,
   ModuleInstance,
   ProfileSummary,
+  ModuleLoadError,
 } from '../shared/types';
 
 type Envelope<T> = { ok: true; data: T } | { ok: false; error: string; details?: unknown };
@@ -29,6 +30,7 @@ const api = {
   listModules: (): Promise<LoadedModule[]> => invoke(IPC.MODULES_LIST),
   reloadModules: (): Promise<LoadedModule[]> => invoke(IPC.MODULES_RELOAD),
   openModulesDir: (): Promise<void> => invoke(IPC.MODULES_OPEN_DIR),
+  listModuleErrors: (): Promise<ModuleLoadError[]> => invoke(IPC.MODULES_LIST_ERRORS),
 
   addInstance: (moduleId: string): Promise<ModuleInstance> =>
     invoke(IPC.INSTANCES_ADD, moduleId),

--- a/src/main/services/ipcService.ts
+++ b/src/main/services/ipcService.ts
@@ -54,6 +54,8 @@ export class IpcService implements Service {
 
     this.router.register(IPC.MODULES_OPEN_DIR, { handler: () => registry.openUserDir() });
 
+    this.router.register(IPC.MODULES_LIST_ERRORS, { handler: () => registry.errors() });
+
     this.router.register(IPC.INSTANCES_ADD, {
       input: moduleIdSchema,
       handler: async (moduleId) => {

--- a/src/main/services/moduleRegistryService.ts
+++ b/src/main/services/moduleRegistryService.ts
@@ -1,8 +1,9 @@
 import { shell } from 'electron';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { z } from 'zod';
 import { manifestSchema } from '../../shared/schemas';
-import type { LoadedModule } from '../../shared/types';
+import type { LoadedModule, ModuleLoadError } from '../../shared/types';
 import type { Service, ServiceContext } from '../core/service';
 import type { Logger } from '../core/logger';
 import { resolveModuleFile } from '../core/security';
@@ -21,6 +22,7 @@ export class ModuleRegistryService implements Service {
   readonly name = 'modules';
   private logger!: Logger;
   private modules = new Map<string, LoadedModule>();
+  private loadErrors: ModuleLoadError[] = [];
   private userDir = '';
   private bundledDir = '';
   private bus!: ServiceContext['bus'];
@@ -37,6 +39,7 @@ export class ModuleRegistryService implements Service {
 
   async load(): Promise<LoadedModule[]> {
     this.modules.clear();
+    this.loadErrors = [];
     for (const dir of [this.bundledDir, this.userDir]) {
       try {
         const entries = await fs.readdir(dir, { withFileTypes: true });
@@ -50,7 +53,9 @@ export class ModuleRegistryService implements Service {
         if (err?.code !== 'ENOENT') this.logger.warn(`scan failed: ${dir}`, err);
       }
     }
-    this.logger.info(`loaded ${this.modules.size} module(s)`);
+    this.logger.info(
+      `loaded ${this.modules.size} module(s); ${this.loadErrors.length} error(s)`,
+    );
     return this.list();
   }
 
@@ -99,8 +104,35 @@ export class ModuleRegistryService implements Service {
       return loaded;
     } catch (err) {
       this.logger.warn(`invalid module at ${modulePath}`, err);
+      this.recordLoadError(modulePath, err);
       return null;
     }
+  }
+
+  /**
+   * Capture a structured load error so the renderer can surface it in
+   * Settings → Modules. Zod errors get a list of issue paths; other
+   * errors collapse to a single message.
+   */
+  private recordLoadError(modulePath: string, err: unknown): void {
+    let message = 'Unknown error';
+    let details: string[] | undefined;
+    if (err instanceof z.ZodError) {
+      message = 'Manifest validation failed';
+      details = err.issues.map(
+        (issue) => `${issue.path.join('.') || '(root)'}: ${issue.message}`,
+      );
+    } else if (err instanceof SyntaxError) {
+      message = `Manifest is not valid JSON: ${err.message}`;
+    } else if (err instanceof Error) {
+      message = err.message;
+    }
+    this.loadErrors.push({ path: modulePath, message, details });
+  }
+
+  /** Per-module load errors from the last load/reload. Surfaced in the UI. */
+  errors(): ModuleLoadError[] {
+    return [...this.loadErrors];
   }
 
   get(id: string): LoadedModule | undefined {

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -15,6 +15,7 @@ export function SettingsPanel({ onClose }: Props) {
   const [tab, setTab] = useState<Tab>('modules');
 
   const modules = useNexus((s) => s.modules);
+  const moduleErrors = useNexus((s) => s.moduleErrors);
   const instances = useNexus((s) => s.state.instances);
   const notificationsEnabled = useNexus((s) => s.state.notificationsEnabled ?? true);
   const notificationSound = useNexus((s) => s.state.notificationSound ?? true);
@@ -167,6 +168,37 @@ export function SettingsPanel({ onClose }: Props) {
                 <strong>instances</strong> of any module to log in with separate accounts —
                 e.g. two WhatsApps, one work, one personal.
               </p>
+
+              {moduleErrors.length > 0 && (
+                <div className="module-errors" role="alert">
+                  <h3>
+                    Couldn't load {moduleErrors.length} module
+                    {moduleErrors.length === 1 ? '' : 's'}
+                  </h3>
+                  <p className="editor-hint">
+                    These directories were skipped because their{' '}
+                    <code>nexus-module.json</code> is missing or invalid. Fix the issues
+                    below and click <strong>Reload modules</strong>.
+                  </p>
+                  <ul className="module-errors-list">
+                    {moduleErrors.map((e) => (
+                      <li key={e.path} className="module-error-row">
+                        <div className="module-error-path">{e.path}</div>
+                        <div className="module-error-message">{e.message}</div>
+                        {e.details && e.details.length > 0 && (
+                          <ul className="module-error-details">
+                            {e.details.map((d, i) => (
+                              <li key={i}>
+                                <code>{d}</code>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
 
               <ul className="module-settings" role="list">
                 {modules.map((m) => {

--- a/src/renderer/nexus.d.ts
+++ b/src/renderer/nexus.d.ts
@@ -7,6 +7,7 @@ import type {
   SidebarLayout,
   ModuleInstance,
   ProfileSummary,
+  ModuleLoadError,
 } from '../shared/types';
 
 export interface UpdateInfo {
@@ -32,6 +33,7 @@ declare global {
       listModules(): Promise<LoadedModule[]>;
       reloadModules(): Promise<LoadedModule[]>;
       openModulesDir(): Promise<void>;
+      listModuleErrors(): Promise<ModuleLoadError[]>;
 
       addInstance(moduleId: string): Promise<ModuleInstance>;
       removeInstance(instanceId: string): Promise<void>;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -7,6 +7,7 @@ import type {
   ModuleInstance,
   ProfileSummary,
   ProfileState,
+  ModuleLoadError,
 } from '../shared/types';
 import { defaultLayout } from '../shared/sidebarLayout';
 
@@ -39,6 +40,7 @@ type CompositeState = AppState & {
 
 interface NexusStore {
   modules: LoadedModule[];
+  moduleErrors: ModuleLoadError[];
   themes: Theme[];
   state: CompositeState;
   unread: Record<string, number>;
@@ -183,6 +185,7 @@ async function refreshComposite(): Promise<CompositeState> {
 
 export const useNexus = create<NexusStore>((set, get) => ({
   modules: [],
+  moduleErrors: [],
   themes: [],
   state: DEFAULT_STATE,
   unread: {},
@@ -201,9 +204,10 @@ export const useNexus = create<NexusStore>((set, get) => ({
 
   async init() {
     try {
-      const [modules, themes, composite, unread, profiles, currentProfile] =
+      const [modules, moduleErrors, themes, composite, unread, profiles, currentProfile] =
         await Promise.all([
           window.nexus.listModules(),
+          window.nexus.listModuleErrors(),
           window.nexus.listThemes(),
           refreshComposite(),
           window.nexus.getAllUnread(),
@@ -212,6 +216,7 @@ export const useNexus = create<NexusStore>((set, get) => ({
         ]);
       set({
         modules,
+        moduleErrors,
         themes,
         state: composite,
         unread,
@@ -280,8 +285,11 @@ export const useNexus = create<NexusStore>((set, get) => ({
   },
 
   async reloadModules() {
-    const modules = await window.nexus.reloadModules();
-    set({ modules });
+    const [modules, moduleErrors] = await Promise.all([
+      window.nexus.reloadModules(),
+      window.nexus.listModuleErrors(),
+    ]);
+    set({ modules, moduleErrors });
   },
 
   async reloadActiveInstance() {
@@ -415,6 +423,7 @@ export const useNexus = create<NexusStore>((set, get) => ({
     // copies defensively in case the reload is slow.
     set({
       modules: [],
+      moduleErrors: [],
       themes: [],
       state: DEFAULT_STATE,
       unread: {},

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2071,3 +2071,58 @@ img.sidebar-logo.app-icon-img {
   border-radius: 4px;
   color: var(--nx-text);
 }
+
+/* Module load errors panel */
+.module-errors {
+  margin: 12px 0 16px 0;
+  padding: 12px 14px;
+  background: rgba(255, 99, 71, 0.08);
+  border: 1px solid rgba(255, 99, 71, 0.4);
+  border-radius: 8px;
+}
+
+.module-errors h3 {
+  margin: 0 0 6px 0;
+  font-size: 13px;
+  color: var(--nx-badge);
+}
+
+.module-errors-list {
+  list-style: none;
+  margin: 8px 0 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.module-error-row {
+  padding: 8px 10px;
+  background: var(--nx-bg);
+  border: 1px solid var(--nx-border);
+  border-radius: 6px;
+}
+
+.module-error-path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--nx-text-muted);
+  overflow-wrap: anywhere;
+}
+
+.module-error-message {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--nx-text);
+}
+
+.module-error-details {
+  margin: 6px 0 0 0;
+  padding-left: 18px;
+  list-style: disc;
+}
+
+.module-error-details code {
+  font-size: 11px;
+  color: var(--nx-text-muted);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -34,6 +34,21 @@ export interface LoadedModule {
   iconDataUrl?: string;
 }
 
+/**
+ * Reported by ModuleRegistryService when a directory under modules/ or
+ * ~/.nexus/modules/ couldn't be loaded as a module — usually because of
+ * a malformed manifest. Surfaced in Settings → Modules so users can fix
+ * the issue without digging through logs.
+ */
+export interface ModuleLoadError {
+  /** Absolute filesystem path of the module directory. */
+  path: string;
+  /** Short human-readable explanation. */
+  message: string;
+  /** Optional structured details, e.g. Zod issue paths for manifest errors. */
+  details?: string[];
+}
+
 export interface UnreadUpdate {
   moduleId: string;
   count: number;
@@ -52,6 +67,7 @@ export const IPC = {
   MODULES_LIST: 'nexus:modules:list',
   MODULES_OPEN_DIR: 'nexus:modules:open-dir',
   MODULES_RELOAD: 'nexus:modules:reload',
+  MODULES_LIST_ERRORS: 'nexus:modules:list-errors',
   INSTANCES_ACTIVATE: 'nexus:instances:activate',
   /**
    * Push-event channel: main → renderer. Fires whenever the active instance


### PR DESCRIPTION
## Summary

When a directory under \`modules/\` or \`~/.nexus/modules/\` can't be loaded as a module (usually a malformed \`nexus-module.json\`), Nexus previously just logged a warning and silently skipped it. Users would notice "Hey, my custom module isn't showing up" with no signal about why.

This PR surfaces those load errors directly in **Settings → Modules**, with the validation issue paths spelled out where possible.

> **Branch base:** \`feat/settings-import-export\` — fourth in the stack. Merge in order: #6 → #7 → #8 → this.

## What's shown

For each rejected module directory:
- Its absolute filesystem path (monospace, so it's copy-pasteable).
- A human-readable error message.
- For Zod manifest-validation failures: a bulleted list of each issue, formatted as \`path.to.field: explanation\` (e.g. \`url: module url must be https\`).
- For JSON parse errors: the parser's own message (\`Manifest is not valid JSON: Unexpected token …\`).

The panel only renders when there are errors, so the UI stays clean for users with no broken modules. Clicking the existing **Reload modules** button re-runs the scan and refreshes both the working modules list AND the errors list — fix-and-reload loop converges on an empty panel.

## Scope (deliberately narrow)

The original ask included three "module devtools" capabilities:

1. **Better error surfacing when a manifest is malformed** ← shipped here.
2. **"Validate manifest" command** — overlapping with #1 (showing manifest errors). A standalone file-picker validator for module authors is genuinely useful but doesn't fit a 1-PR scope. Punted to v2.
3. **Hot-reload local modules without restarting** — the existing **Reload modules** button is the manual-trigger version. A file watcher would be nicer but adds a dependency (chokidar/native FS watch) and dev-only UX considerations. Punted to v2.

## Implementation

- New \`ModuleLoadError\` type in shared types.
- New IPC channel \`nexus:modules:list-errors\`.
- \`ModuleRegistryService\` clears its error list at the start of each load and pushes a structured \`{ path, message, details? }\` for each rejected module. Errors are categorised by type: Zod (paths + issue messages), SyntaxError (JSON parse), or generic Error.
- Renderer store fetches errors in \`init()\` alongside modules, and in \`reloadModules()\` both lists refresh in parallel.
- Settings → Modules renders the panel conditionally when \`moduleErrors.length > 0\`.

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test\` — 178/178 passing
- [x] \`npm run build\` — renderer + main both clean
- [ ] Manual smoke: drop a directory under \`~/.nexus/modules/\` with a broken \`nexus-module.json\` (e.g. \`{ "id": "test" }\` — missing required \`name\` / \`version\` / \`url\`). Click **Reload modules**. The error panel should appear listing the missing fields with their schema paths.
- [ ] Manual smoke: drop a directory with malformed JSON (\`{ this is not json\`). Reload. The panel should show the JSON parse error.
- [ ] Manual smoke: fix one of the broken modules, leave another broken, reload. The error panel should now show only the still-broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)