### PR TITLE
feat: auto-hibernate inactive instances to reclaim memory

### DIFF
--- a/src/main/core/eventBus.ts
+++ b/src/main/core/eventBus.ts
@@ -14,6 +14,8 @@ export interface NexusEvents {
   'view:ready': { instanceId: string };
   'view:load-failed': { instanceId: string; error: string };
   'view:crashed': { instanceId: string; reason: string };
+  'instance:hibernated': { instanceId: string };
+  'instance:woken': { instanceId: string };
   'notification:update': UnreadUpdate;
   'notification:native': {
     instanceId: string;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -113,6 +113,18 @@ const api = {
     invoke(IPC.PREFS_SET_GLOBAL_SHORTCUT_ENABLED, enabled),
   setGlobalShortcut: (accelerator: string): Promise<void> =>
     invoke(IPC.PREFS_SET_GLOBAL_SHORTCUT, accelerator),
+  setHibernateAfterMinutes: (minutes: number | null): Promise<void> =>
+    invoke(IPC.PREFS_SET_HIBERNATE_MINUTES, minutes),
+  onInstanceHibernated: (cb: (instanceId: string) => void): (() => void) => {
+    const listener = (_: unknown, payload: { instanceId: string }) => cb(payload.instanceId);
+    ipcRenderer.on(IPC.INSTANCE_HIBERNATED, listener);
+    return () => ipcRenderer.removeListener(IPC.INSTANCE_HIBERNATED, listener);
+  },
+  onInstanceWoken: (cb: (instanceId: string) => void): (() => void) => {
+    const listener = (_: unknown, payload: { instanceId: string }) => cb(payload.instanceId);
+    ipcRenderer.on(IPC.INSTANCE_WOKEN, listener);
+    return () => ipcRenderer.removeListener(IPC.INSTANCE_WOKEN, listener);
+  },
   testNotification: (instanceId?: string | null): Promise<boolean> =>
     invoke(IPC.NOTIFY_TEST, instanceId ?? null),
 

--- a/src/main/services/ipcService.ts
+++ b/src/main/services/ipcService.ts
@@ -378,6 +378,16 @@ export class IpcService implements Service {
       },
     });
 
+    this.router.register(IPC.PREFS_SET_HIBERNATE_MINUTES, {
+      // null/undefined → disabled, otherwise 5..480
+      input: z.number().int().min(0).max(480).nullable(),
+      handler: (minutes) => {
+        settings.setHibernateAfterMinutes(
+          minutes === null || minutes === 0 ? undefined : minutes,
+        );
+      },
+    });
+
     this.router.register(IPC.SIDEBAR_UPDATE_LAYOUT, {
       input: sidebarLayoutSchema,
       handler: (layout) => {
@@ -566,6 +576,25 @@ export class IpcService implements Service {
         const win = windowSvc.getWindow();
         if (win && !win.isDestroyed()) {
           win.webContents.send(IPC.VIEW_CRASHED, { instanceId, reason });
+        }
+      }),
+    );
+
+    // Forward hibernation lifecycle events so the renderer can show
+    // (and clear) the 💤 indicator on the sidebar.
+    this.teardowns.push(
+      ctx.bus.on('instance:hibernated', ({ instanceId }) => {
+        const win = windowSvc.getWindow();
+        if (win && !win.isDestroyed()) {
+          win.webContents.send(IPC.INSTANCE_HIBERNATED, { instanceId });
+        }
+      }),
+    );
+    this.teardowns.push(
+      ctx.bus.on('instance:woken', ({ instanceId }) => {
+        const win = windowSvc.getWindow();
+        if (win && !win.isDestroyed()) {
+          win.webContents.send(IPC.INSTANCE_WOKEN, { instanceId });
         }
       }),
     );

--- a/src/main/services/settingsService.ts
+++ b/src/main/services/settingsService.ts
@@ -170,6 +170,22 @@ export class SettingsService implements Service {
     this.queueWrite();
   }
 
+  /**
+   * Configure auto-hibernation of inactive instances.
+   * Pass `undefined` (or 0) to disable. Otherwise minutes 5..480.
+   */
+  setHibernateAfterMinutes(minutes: number | undefined): void {
+    let normalized: number | undefined;
+    if (minutes === undefined || minutes === 0) {
+      normalized = undefined;
+    } else {
+      normalized = Math.max(5, Math.min(480, Math.round(minutes)));
+    }
+    if (this._state.hibernateAfterMinutes === normalized) return;
+    this._state = { ...this._state, hibernateAfterMinutes: normalized };
+    this.queueWrite();
+  }
+
   setWindowState(ws: AppState['windowState']): void {
     this._state = { ...this._state, windowState: ws };
     this.queueWrite();

--- a/src/main/services/viewService.ts
+++ b/src/main/services/viewService.ts
@@ -7,6 +7,7 @@ import type { Service, ServiceContext } from '../core/service';
 import type { Logger } from '../core/logger';
 import type { ModuleRegistryService } from './moduleRegistryService';
 import type { WindowService } from './windowService';
+import type { SettingsService } from './settingsService';
 import type { ProfileService } from './profileService';
 import { DefaultStrategyFactory } from './notifications/strategies';
 import type { NotificationStrategy, StrategyFactory } from './notifications/strategy';
@@ -34,6 +35,16 @@ export class ViewService implements Service {
   private bounds: Bounds = { x: 220, y: 40, width: 800, height: 600 };
   private suspended = false;
   private strategyFactory: StrategyFactory = new DefaultStrategyFactory();
+  /** Wall-clock ms of last `activate(id)` per instance — used by the
+   *  hibernation timer to find idle views. Not persisted; resets per
+   *  Nexus session. Each entry seeds to `Date.now()` when the view is
+   *  first ensured, so a freshly created instance has a "young" age. */
+  private lastActiveAt = new Map<string, number>();
+  /** Set of instance ids whose WebContentsView has been destroyed by the
+   *  hibernation timer. ensure() consults this to know whether to emit
+   *  `instance:woken` (rather than just `view:created`) on recreation. */
+  private hibernatedIds = new Set<string>();
+  private hibernateTimer: NodeJS.Timeout | null = null;
 
   async init(ctx: ServiceContext): Promise<void> {
     this.ctx = ctx;
@@ -41,10 +52,68 @@ export class ViewService implements Service {
     this.registry = ctx.container.get<ModuleRegistryService>('modules');
     this.windowService = ctx.container.get<WindowService>('window');
     this.profiles = ctx.container.get<ProfileService>('profiles');
+
+    // Check every 60s for views that have been idle longer than the
+    // configured threshold and hibernate them. Cheap operation — usually
+    // a no-op since most users have few instances and short sessions.
+    this.hibernateTimer = setInterval(() => {
+      this.runHibernationSweep();
+    }, 60_000);
   }
 
   async dispose(): Promise<void> {
+    if (this.hibernateTimer) {
+      clearInterval(this.hibernateTimer);
+      this.hibernateTimer = null;
+    }
     this.destroyAll();
+  }
+
+  /**
+   * Destroy WebContentsViews for any non-active instance whose last activation
+   * is older than `settings.hibernateAfterMinutes`. No-op when the feature
+   * is disabled or no instances qualify. Emits `instance:hibernated` per
+   * hibernated id so the renderer can mark them with a sleep indicator.
+   */
+  private runHibernationSweep(): void {
+    let settings: SettingsService | null = null;
+    try {
+      settings = this.ctx.container.get<SettingsService>('settings');
+    } catch {
+      return; // SettingsService not registered (tests)
+    }
+    const minutes = settings?.state.hibernateAfterMinutes;
+    if (!minutes || minutes <= 0) return;
+    const threshold = Date.now() - minutes * 60_000;
+    for (const [id, mv] of this.views) {
+      if (id === this.activeId) continue;
+      const last = this.lastActiveAt.get(id) ?? 0;
+      if (last > threshold) continue;
+      this.logger.info(`hibernating idle instance ${id} (last active ${new Date(last).toISOString()})`);
+      // Tear down the view but DON'T forget about the instance — we want
+      // ensure() to know it was hibernated so it can emit `instance:woken`.
+      try {
+        const win = this.windowService.getWindow();
+        if (win && !win.isDestroyed()) {
+          try {
+            win.contentView.removeChildView(mv.view);
+          } catch {
+            /* not attached */
+          }
+        }
+        mv.strategy?.detach();
+        try {
+          mv.view.webContents.close();
+        } catch {
+          /* already closed */
+        }
+      } finally {
+        this.views.delete(id);
+        this.lastActiveAt.delete(id);
+        this.hibernatedIds.add(id);
+        this.ctx.bus.emit('instance:hibernated', { instanceId: id });
+      }
+    }
   }
 
   /**
@@ -85,8 +154,16 @@ export class ViewService implements Service {
     const mod = this.registry.get(instance.moduleId);
     if (!mod) throw new Error(`module not found for instance ${instanceId}: ${instance.moduleId}`);
 
+    const wasHibernated = this.hibernatedIds.has(instanceId);
     const mv = this.create(instance, mod);
     this.views.set(instanceId, mv);
+    // Seed last-active time so a freshly-ensured-but-not-yet-activated view
+    // doesn't immediately qualify for hibernation in the same tick.
+    this.lastActiveAt.set(instanceId, Date.now());
+    if (wasHibernated) {
+      this.hibernatedIds.delete(instanceId);
+      this.ctx.bus.emit('instance:woken', { instanceId });
+    }
     this.ctx.bus.emit('view:created', { instanceId });
     return mv;
   }
@@ -114,6 +191,7 @@ export class ViewService implements Service {
     }
 
     this.activeId = instanceId;
+    this.lastActiveAt.set(instanceId, Date.now());
     mv.view.setBounds(this.suspended ? HIDDEN : this.bounds);
     this.ctx.bus.emit('instance:activated', { instanceId });
   }
@@ -136,6 +214,8 @@ export class ViewService implements Service {
       // ignore
     }
     this.views.delete(instanceId);
+    this.lastActiveAt.delete(instanceId);
+    this.hibernatedIds.delete(instanceId);
     if (this.activeId === instanceId) this.activeId = null;
     this.ctx.bus.emit('view:destroyed', { instanceId });
   }

--- a/src/renderer/components/SettingsPanel.tsx
+++ b/src/renderer/components/SettingsPanel.tsx
@@ -27,6 +27,8 @@ export function SettingsPanel({ onClose }: Props) {
   const closeToTray = useNexus((s) => s.state.closeToTray ?? false);
   const globalShortcutEnabled = useNexus((s) => s.state.globalShortcutEnabled ?? false);
   const globalShortcut = useNexus((s) => s.state.globalShortcut ?? 'Alt+`');
+  const hibernateAfterMinutes = useNexus((s) => s.state.hibernateAfterMinutes);
+  const setHibernateAfterMinutes = useNexus((s) => s.setHibernateAfterMinutes);
 
   const setNotificationsEnabled = useNexus((s) => s.setNotificationsEnabled);
   const setNotificationSound = useNexus((s) => s.setNotificationSound);
@@ -456,6 +458,46 @@ export function SettingsPanel({ onClose }: Props) {
                   <dt><kbd>Esc</kbd></dt>
                   <dd>Close settings</dd>
                 </dl>
+              </div>
+
+              <div className="settings-performance">
+                <h3>Performance</h3>
+                <label className="settings-toggle">
+                  <input
+                    type="checkbox"
+                    checked={hibernateAfterMinutes !== undefined}
+                    onChange={(e) => {
+                      void setHibernateAfterMinutes(e.target.checked ? 60 : null);
+                    }}
+                  />
+                  <div>
+                    <div className="settings-toggle-title">Hibernate inactive instances</div>
+                    <div className="settings-toggle-desc">
+                      Reclaim memory by tearing down embedded webviews for instances you
+                      haven't used in a while. Re-activating an instance reloads its page
+                      (slow first activation). The currently-active instance is never
+                      hibernated.
+                    </div>
+                  </div>
+                </label>
+                {hibernateAfterMinutes !== undefined && (
+                  <label className="settings-field" style={{ marginTop: 8 }}>
+                    Hibernate after
+                    <input
+                      type="number"
+                      min={5}
+                      max={480}
+                      value={hibernateAfterMinutes}
+                      onChange={(e) => {
+                        const n = Number(e.target.value);
+                        if (!Number.isFinite(n)) return;
+                        void setHibernateAfterMinutes(Math.max(5, Math.min(480, Math.round(n))));
+                      }}
+                      style={{ width: 80 }}
+                    />
+                    minutes of inactivity
+                  </label>
+                )}
               </div>
 
               <div className="settings-backup">

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -38,6 +38,7 @@ export function Sidebar() {
   const layout = useNexus((s) => s.state.sidebarLayout ?? defaultLayout());
   const activeId = useNexus((s) => s.state.activeInstanceId);
   const unread = useNexus((s) => s.unread);
+  const hibernatedInstances = useNexus((s) => s.hibernatedInstances);
   const savedCompact = useNexus((s) => s.state.sidebarCompact ?? false);
   const savedWidth = useNexus((s) => s.state.sidebarWidth ?? 240);
   const activate = useNexus((s) => s.activateInstance);
@@ -355,6 +356,7 @@ export function Sidebar() {
                   {entries.map((instance) => {
                     const m = modulesById.get(instance.moduleId);
                     const count = unread[instance.id] ?? 0;
+                    const isHibernated = hibernatedInstances[instance.id] === true;
                     const isActive = activeId === instance.id;
                     const hintKey = `${group.id}:${instance.id}`;
                     const showAbove = dropHint === `${hintKey}:before`;
@@ -433,6 +435,15 @@ export function Sidebar() {
                               aria-label={`${count} unread`}
                             >
                               {count > 99 ? '99+' : count}
+                            </span>
+                          )}
+                          {isHibernated && !isRenaming && (
+                            <span
+                              className="hibernate-indicator"
+                              title="Hibernated to save memory. Click to wake."
+                              aria-label="Hibernated"
+                            >
+                              💤
                             </span>
                           )}
                           {!isRenaming && (

--- a/src/renderer/nexus.d.ts
+++ b/src/renderer/nexus.d.ts
@@ -79,6 +79,9 @@ declare global {
       setCloseToTray(enabled: boolean): Promise<void>;
       setGlobalShortcutEnabled(enabled: boolean): Promise<void>;
       setGlobalShortcut(accelerator: string): Promise<void>;
+      setHibernateAfterMinutes(minutes: number | null): Promise<void>;
+      onInstanceHibernated(cb: (instanceId: string) => void): () => void;
+      onInstanceWoken(cb: (instanceId: string) => void): () => void;
       testNotification(instanceId?: string | null): Promise<boolean>;
 
       listProfiles(): Promise<ProfileSummary[]>;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -66,6 +66,13 @@ interface NexusStore {
    */
   crashedInstances: Record<string, { reason: string }>;
 
+  /**
+   * Set of instance ids whose WebContentsView has been torn down by the
+   * hibernation timer. The sidebar shows a sleep indicator for these.
+   * Cleared when the instance is activated and its view is recreated.
+   */
+  hibernatedInstances: Record<string, true>;
+
   init(): Promise<void>;
   activateInstance(instanceId: string): Promise<void>;
   addInstance(moduleId: string): Promise<ModuleInstance>;
@@ -87,6 +94,8 @@ interface NexusStore {
   setCloseToTray(enabled: boolean): Promise<void>;
   setGlobalShortcutEnabled(enabled: boolean): Promise<void>;
   setGlobalShortcut(accelerator: string): Promise<void>;
+  /** Configure auto-hibernation. Pass null to disable, or 5..480 minutes. */
+  setHibernateAfterMinutes(minutes: number | null): Promise<void>;
   testNotification(): Promise<boolean>;
   exportThemePack(
     ids: string[],
@@ -201,6 +210,7 @@ export const useNexus = create<NexusStore>((set, get) => ({
   currentProfile: null,
   accountManagerOpen: false,
   crashedInstances: {},
+  hibernatedInstances: {},
 
   async init() {
     try {
@@ -249,6 +259,21 @@ export const useNexus = create<NexusStore>((set, get) => ({
         set((s) => ({
           crashedInstances: { ...s.crashedInstances, [instanceId]: { reason } },
         }));
+      });
+
+      // Track hibernation state for the sidebar's 💤 indicator.
+      window.nexus.onInstanceHibernated((instanceId) => {
+        set((s) => ({
+          hibernatedInstances: { ...s.hibernatedInstances, [instanceId]: true as const },
+        }));
+      });
+      window.nexus.onInstanceWoken((instanceId) => {
+        set((s) => {
+          if (!s.hibernatedInstances[instanceId]) return {};
+          const next = { ...s.hibernatedInstances };
+          delete next[instanceId];
+          return { hibernatedInstances: next };
+        });
       });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : String(err), ready: true });
@@ -380,6 +405,13 @@ export const useNexus = create<NexusStore>((set, get) => ({
     if (!trimmed) return;
     await window.nexus.setGlobalShortcut(trimmed);
     set((s) => ({ state: { ...s.state, globalShortcut: trimmed } }));
+  },
+
+  async setHibernateAfterMinutes(minutes) {
+    await window.nexus.setHibernateAfterMinutes(minutes);
+    set((s) => ({
+      state: { ...s.state, hibernateAfterMinutes: minutes ?? undefined },
+    }));
   },
 
   async testNotification() {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -2126,3 +2126,32 @@ img.sidebar-logo.app-icon-img {
   font-size: 11px;
   color: var(--nx-text-muted);
 }
+
+/* Hibernate sidebar indicator */
+.hibernate-indicator {
+  margin-left: 4px;
+  font-size: 11px;
+  opacity: 0.7;
+  cursor: help;
+}
+
+/* Settings — Performance section */
+.settings-performance {
+  margin-top: 24px;
+  padding: 16px;
+  border: 1px solid var(--nx-border);
+  border-radius: 8px;
+}
+
+.settings-performance h3 {
+  margin: 0 0 12px 0;
+  font-size: 14px;
+}
+
+.settings-performance .settings-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--nx-text-muted);
+}

--- a/src/shared/schemas.ts
+++ b/src/shared/schemas.ts
@@ -137,6 +137,17 @@ export const appStateSchema = z.object({
   closeToTray: z.boolean().optional(),
   globalShortcutEnabled: z.boolean().optional(),
   globalShortcut: z.string().max(64).optional(),
+  /**
+   * Auto-hibernate inactive instances after this many minutes to reclaim
+   * memory. When undefined or 0 the feature is disabled. Range 5–480
+   * (5 minutes to 8 hours) when set.
+   *
+   * Hibernating destroys the embedded WebContentsView, freeing the
+   * underlying Chromium tab's memory. Re-activating the instance later
+   * recreates the view (slow first activation — the page has to load
+   * again). The active instance is never hibernated.
+   */
+  hibernateAfterMinutes: z.number().int().min(5).max(480).optional(),
   windowState: z
     .object({
       x: z.number().optional(),

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -88,6 +88,18 @@ export const IPC = {
    * so the user can reload or dismiss.
    */
   VIEW_CRASHED: 'nexus:view:crashed',
+  /**
+   * Push-event channel: main → renderer. Fires when ViewService destroys
+   * an idle instance's WebContentsView to reclaim memory. Renderer marks
+   * the instance with a sleep indicator in the sidebar.
+   */
+  INSTANCE_HIBERNATED: 'nexus:instance:hibernated',
+  /**
+   * Push-event channel: main → renderer. Fires when ViewService recreates
+   * a previously-hibernated instance's WebContentsView (because the user
+   * activated it). Renderer clears the sleep indicator.
+   */
+  INSTANCE_WOKEN: 'nexus:instance:woken',
   THEMES_LIST: 'nexus:themes:list',
   THEMES_SET: 'nexus:themes:set',
   THEMES_SAVE: 'nexus:themes:save',
@@ -113,6 +125,7 @@ export const IPC = {
   PREFS_SET_CLOSE_TO_TRAY: 'nexus:prefs:set-close-to-tray',
   PREFS_SET_GLOBAL_SHORTCUT_ENABLED: 'nexus:prefs:set-global-shortcut-enabled',
   PREFS_SET_GLOBAL_SHORTCUT: 'nexus:prefs:set-global-shortcut',
+  PREFS_SET_HIBERNATE_MINUTES: 'nexus:prefs:set-hibernate-minutes',
   PROFILES_LIST: 'nexus:profiles:list',
   PROFILES_CURRENT: 'nexus:profiles:current',
   PROFILES_STATE: 'nexus:profiles:state',


### PR DESCRIPTION
## Summary

Big win for users with 8+ instances open: an opt-in setting that destroys the embedded WebContentsView for any non-active instance that's been idle longer than a configured threshold (default 60 min when enabled, range 5–480 min). The instance keeps its sidebar entry, gets a 💤 indicator, and re-activating it rebuilds the view from scratch.

> **Branch base:** \`feat/module-devtools\` — fifth and final in the stack. Merge order: #6 → #7 → #8 → #9 → this.

## Why

Each embedded WebContentsView is a full Chromium tab — easily 100–300 MB of RAM each. A user with 8 instances (work WhatsApp, personal WhatsApp, work Slack, personal Slack, Telegram, Messenger, Teams, Instagram) is sitting at 1–2 GB just for Nexus's webviews, even when they're only actively using one. Hibernation can reclaim most of that.

## What you give up by enabling it

When an instance hibernates, its WebContentsView is destroyed. The instance loses:

- Open conversation scroll position
- Composing-message draft text (if the provider didn't save it to localStorage — most do, but not guaranteed)
- Any uncommitted in-page state

Hence **opt-in by default**. The toggle is in **Settings → General → Performance** with a clear description of the tradeoff.

## Design choices

- **Active instance is never hibernated** — only background instances qualify.
- **Sweep runs every 60s** with a wall-clock comparison. Cheap and good-enough.
- **Range 5–480 min** clamped on both ends. 5 min minimum prevents thrash; 8h ceiling is just a sanity bound.
- **\`lastActiveAt\` seeded on \`ensure()\`** — a freshly-created instance has a "young" age and won't be hibernated in the same tick.
- **No \`view:created\` swallow when waking** — the existing event still fires alongside a new \`instance:woken\`, so downstream consumers that already watch view-creation keep working.

## Architecture

Same main → bus → IPC → renderer pattern as the rest of this stack:

- New bus events: \`instance:hibernated\`, \`instance:woken\`.
- New IPC channels: \`nexus:instance:hibernated\`, \`nexus:instance:woken\`, \`nexus:prefs:set-hibernate-minutes\`.
- New renderer store slice: \`hibernatedInstances: Record<id, true>\`.
- Sidebar pulls from the slice and renders the 💤 conditionally next to the instance name.
- Settings → General → Performance: a toggle + numeric input (only shown when toggle is on).

## Test plan

- [x] \`npm run typecheck\` — clean
- [x] \`npm run test\` — 178/178 passing
- [x] \`npm run build\` — renderer + main both clean
- [ ] Manual smoke: enable hibernate at 5 min in Settings → Performance. Open WhatsApp, switch to Telegram, leave for 6 min. Watch the WhatsApp sidebar row: a 💤 should appear. Click WhatsApp — the page reloads (\"slow first activation\"), 💤 disappears.
- [ ] Manual smoke: with hibernate enabled, make sure the *currently-active* instance does NOT get hibernated even if it's been on screen for an hour. (Activate, leave, return — no 💤 on the active one.)
- [ ] Manual smoke: disable hibernate via the toggle. Verify previously-hibernated instances don't re-trigger and that no new hibernations happen on the timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)